### PR TITLE
Allow different signer in Albedo

### DIFF
--- a/src/routes/claim/+page.svelte
+++ b/src/routes/claim/+page.svelte
@@ -164,7 +164,8 @@
 
       const { signedXDR } = await kit.sign({
         xdr: transaction.toXDR(),
-        publicKey: pubkey,
+        // albedo does not require this but not specifying it allows to choose different signers in their UI
+        publicKey: wallettype == WalletType.ALBEDO ? undefined : pubkey, 
       })
 
       const txBody = new FormData()


### PR DESCRIPTION
When specifying a public key for Albedo they force you to sign the transaction with the given account.  
When set to undefined they will still default to the source account of the transaction but also allow the user to choose a different account to sign as.  
I have the issue that I use a different signer account then my receiving account and was unable to claim without manually building the transaction. With this update, this is made easier.